### PR TITLE
Properly handle args passed to iStyle

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -44,7 +44,7 @@ function runFormatter(document: vscode.TextDocument): vscode.TextEdit[] {
 		args.push(style);
 	}
 	if (iStyleExtraArgs.length !== 0) {
-		args.push(iStyleExtraArgs);
+		args = args.concat(iStyleExtraArgs.split(" "));
 	}
 	var tempfile: string = createTempFileOfDocument(document);
 	args.push(tempfile);


### PR DESCRIPTION
Should be putting each argument as an individual element in the array otherwise the formatter will not work properly when multiple args are provided.